### PR TITLE
Expected the file extension without a dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ fn main(){
         .location("/path/to/search")
         .search_input("what to search")
         .more_locations(vec!["/anotherPath/to/search", "/keepAddingIfYouWant/"])
-        .ext(".extension")
+        .ext("extension")
         .strict()
         .depth(1)
         .ignore_case()

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -80,12 +80,14 @@ impl SearchBuilder {
     /// use rust_search::SearchBuilder;
     ///
     /// let search: Vec<String> = SearchBuilder::default()
-    /// .ext(".rs")
-    /// .build()
-    /// .collect();
+    ///     .ext("rs")
+    ///     .build()
+    ///     .collect();
     /// ```
     pub fn ext(mut self, ext: impl Into<String>) -> Self {
-        self.file_ext = Some(ext.into());
+        let ext: String = ext.into();
+        // Remove the dot if it's there.
+        self.file_ext = Some(ext.strip_prefix('.').map(str::to_owned).unwrap_or(ext));
         self
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,14 +6,14 @@ pub(crate) fn build_regex_search_input(
     strict: bool,
     ignore_case: bool,
 ) -> Regex {
-    let file_type = file_ext.unwrap_or(".*");
-    let search_input = search_input.unwrap_or(r"\w+\");
-    const FUZZY_SEARCH: &str = r".*\";
+    let file_type = file_ext.unwrap_or("*");
+    let search_input = search_input.unwrap_or(r"\w+");
+    const FUZZY_SEARCH: &str = r".*";
     let mut formatted_search_input;
     if strict {
-        formatted_search_input = format!(r#"{}{}$"#, search_input, file_type);
+        formatted_search_input = format!(r#"{}\.{}$"#, search_input, file_type);
     } else {
-        formatted_search_input = format!(r#"{}{}{}$"#, search_input, FUZZY_SEARCH, file_type);
+        formatted_search_input = format!(r#"{}{}\.{}$"#, search_input, FUZZY_SEARCH, file_type);
     }
     if ignore_case {
         formatted_search_input = set_case_insensitive(&formatted_search_input);


### PR DESCRIPTION
fixes #10

There is no BC with a builder, but there is with `Search::new`. We should make it public for crate only 