### PR TITLE
Clippy linting and CI build/test.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-test:
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+
+          - os: macos-latest
+            target: x86_64-apple-darwin
+
+    name: Build & Test (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+
+    env:
+      RA_TARGET: ${{ matrix.target }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+
+      - name: Install Rust library source
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+          components: rust-src
+
+      - name: Build
+        run: cargo build --verbose --target ${{ matrix.target }}
+
+      - name: Run tests
+        run: cargo test --verbose --target ${{ matrix.target }}
+
+  lint:
+    name: Formatter
+
+    needs: build-test
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add rustfmt
+          rustup component add clippy
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Check code for possible improvements
+        run: cargo clippy -- -D warnings

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -96,7 +96,7 @@ impl SearchBuilder {
     pub fn ext(mut self, ext: impl Into<String>) -> Self {
         let ext: String = ext.into();
         // Remove the dot if it's there.
-        self.file_ext = Some(ext.strip_prefix('.').map(str::to_owned).unwrap_or(ext));
+        self.file_ext = Some(ext.strip_prefix('.').map_or(ext.clone(), str::to_owned));
         self
     }
 
@@ -137,7 +137,7 @@ impl SearchBuilder {
     ///     .build()
     ///     .collect();
     /// ```
-    pub fn depth(mut self, depth: usize) -> Self {
+    pub const fn depth(mut self, depth: usize) -> Self {
         self.depth = Some(depth);
         self
     }
@@ -154,7 +154,7 @@ impl SearchBuilder {
     ///     .build()
     ///     .collect();
     /// ```
-    pub fn limit(mut self, limit: usize) -> Self {
+    pub const fn limit(mut self, limit: usize) -> Self {
         self.limit = Some(limit);
         self
     }
@@ -172,7 +172,7 @@ impl SearchBuilder {
     ///     .build()
     ///     .collect();
     /// ```
-    pub fn strict(mut self) -> Self {
+    pub const fn strict(mut self) -> Self {
         self.strict = true;
         self
     }
@@ -190,7 +190,7 @@ impl SearchBuilder {
     ///     .build()
     ///     .collect();
     /// ```
-    pub fn ignore_case(mut self) -> Self {
+    pub const fn ignore_case(mut self) -> Self {
         self.ignore_case = true;
         self
     }
@@ -205,7 +205,7 @@ impl SearchBuilder {
     ///     .build()
     ///     .collect();
     /// ```
-    pub fn hidden(mut self) -> Self {
+    pub const fn hidden(mut self) -> Self {
         self.hidden = true;
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,13 @@
+#![warn(clippy::nursery, clippy::pedantic)]
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    clippy::module_name_repetitions,
+    clippy::unused_self,
+    clippy::return_self_not_must_use,
+    clippy::must_use_candidate
+)]
 #![warn(missing_docs)]
 // Use the readme as the crate documentation
 #![doc = include_str!("../README.md")]

--- a/src/search.rs
+++ b/src/search.rs
@@ -58,7 +58,7 @@ impl Search {
     /// * `strict` - Whether to search for the exact word or not
     /// * `ignore_case` - Whether to ignore case or not
     /// * `hidden` - Whether to search hidden files or not
-    /// * `filters` - Vector of filters to search by DirEntry data
+    /// * `filters` - Vector of filters to search by `DirEntry` data
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         search_location: impl AsRef<Path>,
@@ -115,9 +115,9 @@ impl Search {
                             {
                                 counter += 1;
                                 return WalkState::Continue;
-                            } else {
-                                return WalkState::Quit;
                             }
+
+                            return WalkState::Quit;
                         }
                     }
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,9 @@ use regex::Regex;
 use std::path::{Path, PathBuf};
 use strsim::jaro_winkler;
 
-pub(crate) fn build_regex_search_input(
+const FUZZY_SEARCH: &str = r".*";
+
+pub fn build_regex_search_input(
     search_input: Option<&str>,
     file_ext: Option<&str>,
     strict: bool,
@@ -10,13 +12,13 @@ pub(crate) fn build_regex_search_input(
 ) -> Regex {
     let file_type = file_ext.unwrap_or("*");
     let search_input = search_input.unwrap_or(r"\w+");
-    const FUZZY_SEARCH: &str = r".*";
-    let mut formatted_search_input;
-    if strict {
-        formatted_search_input = format!(r#"{}\.{}$"#, search_input, file_type);
+
+    let mut formatted_search_input = if strict {
+        format!(r#"{search_input}\.{file_type}$"#)
     } else {
-        formatted_search_input = format!(r#"{}{}\.{}$"#, search_input, FUZZY_SEARCH, file_type);
-    }
+        format!(r#"{search_input}{FUZZY_SEARCH}\.{file_type}$"#)
+    };
+
     if ignore_case {
         formatted_search_input = set_case_insensitive(&formatted_search_input);
     }
@@ -30,7 +32,7 @@ fn set_case_insensitive(formatted_search_input: &str) -> String {
 /// Replace the tilde with the home directory, if it exists
 /// ### Arguments
 /// * `path` - The path to replace the tilde with the home directory
-pub(crate) fn replace_tilde_with_home_dir(path: impl AsRef<Path>) -> PathBuf {
+pub fn replace_tilde_with_home_dir(path: impl AsRef<Path>) -> PathBuf {
     let path = path.as_ref();
     if path.starts_with("~") {
         if let Some(home_dir) = dirs::home_dir() {
@@ -44,7 +46,7 @@ pub(crate) fn replace_tilde_with_home_dir(path: impl AsRef<Path>) -> PathBuf {
 fn file_name_from_path(path: &str) -> String {
     let path = Path::new(path);
     let file_name = path.file_name().unwrap().to_str().unwrap();
-    return file_name.to_string();
+    file_name.to_string()
 }
 
 /// This function can be used to sort the given vector on basis of similarity between the input & the vector
@@ -54,29 +56,31 @@ fn file_name_from_path(path: &str) -> String {
 /// ### Examples
 /// ```rust
 /// use rust_search::{SearchBuilder, similarity_sort};
-/// fn main() {
-///     let search_input = "fly";
-///     let mut search: Vec<String> = SearchBuilder::default()
-///         .location("~/Desktop/")
-///         .search_input(search_input)
-///         .depth(1)
-///         .ignore_case()
-///         .build()
-///         .collect();
+///
+/// let search_input = "fly";
+/// let mut search: Vec<String> = SearchBuilder::default()
+///     .location("~/Desktop/")
+///     .search_input(search_input)
+///     .depth(1)
+///     .ignore_case()
+///     .build()
+///     .collect();
 
-///     similarity_sort(&mut search, &search_input);
-///     for path in search {
-///        println!("{:?}", path);
-///     }
+/// similarity_sort(&mut search, &search_input);
+/// for path in search {
+///     println!("{:?}", path);
 /// }
 /// ```
-/// 
+///
 /// search **without** similarity sort
 /// `["afly.txt", "bfly.txt", "flyer.txt", "fly.txt"]`
-/// 
+///
 /// search **with** similarity sort
 /// `["fly.txt", "flyer.txt", "afly.txt", "bfly.txt",]`
-pub fn similarity_sort(vector: &mut Vec<String>, input: &str) {
+///
+/// ### Panics
+/// Will panic if `partial_cmp` is None
+pub fn similarity_sort(vector: &mut [String], input: &str) {
     vector.sort_by(|a, b| {
         let input = input.to_lowercase();
         let a = file_name_from_path(a).to_lowercase();


### PR DESCRIPTION
Hello!

I saw your post on the Rust community Discord, and thought I'd contribute this project.

The clippy group lints I've added are nursery and pedantic, which can be found [here](https://rust-lang.github.io/rust-clippy/master/index.html). There are some rules that I ignored that can be seen at the [top of `lib.rs`](https://github.com/Xithrius/rust_search/blob/feature/ci-and-clippy/src/lib.rs#L2-L10).

I wasn't sure how to explain what the [similarity sort function](https://github.com/Xithrius/rust_search/blob/feature/ci-and-clippy/src/utils.rs#L83-L92) panics on, so I added a placeholder for the time being.

The CI builds and tests when there's a commit to main or any PR, and runs on the following operating systems and architectures:

```
windows-latest: x86_64-pc-windows-msvc
ubuntu-latest: x86_64-unknown-linux-gnu
macos-latest: x86_64-apple-darwin
```

Happy holidays!